### PR TITLE
add grpc restart ability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 build
 test/code-gen
 test/code-gen-cli
+node_modules

--- a/src/genServices.ts
+++ b/src/genServices.ts
@@ -214,15 +214,14 @@ export default async function genServices(opt: {
       `export let base${service.name[0]}${service.name.slice(1)} = getGrpcClientFactory();`,
       `function getGrpcClientFactory() { return getGrpcClient<${typeName}>(${service.name}) };`,
       `export const ${service.name[0].toLowerCase()}${service.name.slice(1)} = <${typeName}>(new Object());`,
-      `Object.entries(base${service.name[0]}${service.name.slice(1)}.constructor.prototype).filter(([methodName]) => /^[A-Za-z0-9]+$/g.test(methodName)).forEach(item => {
-  ${service.name[0].toLowerCase()}${service.name.slice(1)}[item[0]] = item[1]
-});`,
-      `Object.keys(${service.name[0].toLowerCase()}${service.name.slice(1)}).forEach(item => { Object.defineProperty(${service.name[0].toLowerCase()}${service.name.slice(1)}, item, { 
-  get: function () { return async function (...opction:[]) {
-  try{ return await base${service.name[0]}${service.name.slice(1)}[item](...opction) } catch (err){
-    restrtGrpcRules(base${service.name[0]}${service.name.slice(1)}, err); console.info(err); throw new Error(err) 
-  }}}
-})});`,
+      `Object.entries(base${service.name[0]}${service.name.slice(1)}.constructor.prototype)
+  .filter(([methodName]) => /^[A-Za-z0-9]+$/g.test(methodName)).forEach(item => {
+    ${service.name[0].toLowerCase()}${service.name.slice(1)}[item[0]] = async function (...opction: []) {
+      try { return await base${service.name[0]}${service.name.slice(1)}[item[0]](...opction) } catch (err) {
+        restrtGrpcRules(base${service.name[0]}${service.name.slice(1)}, err); console.info(err); throw new Error(err)
+      }
+    }
+  });`,
       `Service.prototype.restartServer = base${service.name[0]}${service.name.slice(1)}.restartServer = function () { base${service.name[0]}${service.name.slice(1)} = getGrpcClientFactory()};`,
       `Service.prototype.closeServer = base${service.name[0]}${service.name.slice(1)}.closeServer = function () { this.close(); base${service.name[0]}${service.name.slice(1)} = null;}`,
       `const cache = {regs: [/failed.+connect/,/deadline.+exceeded/,/cannot.+read.+property/,/tcp.+read.+failed/,/internal.+http2.+error/,/stream.+removed/]}`,


### PR DESCRIPTION
增加 grpc servers restart 能力
监听每个go服务，若匹配到一下reg的任何一个错误，则restart grpc 服务
grpc服务使用长链接，若匹配到错误则重启
正则匹配条件：
regs: [
    /failed.+connect/,
    /deadline.+exceeded/,
    /cannot.+read.+property/,
    /tcp.+read.+failed/,
    /internal.+http2.+error/,
    /stream.+removed/
  ] 

