### PR TITLE
解决grpc服务名之间冲突问题,解决团队协作冲突，同服务下命名冲突问题

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -110,9 +110,6 @@ export async function gen(opt: Options): Promise<string> {
   );
 
 
-  // 先清空一次
-  // await fs.writeFile(getAbsPath('types.ts', baseDir), '');
-
   allResult.map(async (item: { result: any, root: any, [propname: string]: any }, index: number) => {
 
     const { result, root, space, service } = item

--- a/src/base.ts
+++ b/src/base.ts
@@ -40,45 +40,49 @@ export async function gen(opt: Options): Promise<string> {
 
   fs.mkdirpSync(baseDir);
 
-  const root = await loadProto({
-    gitUrls,
-    branch,
-    accessToken,
-    resolvePath,
-  });
-  root.resolveAll();
+  if (gitUrls.length <= 1) {
+    throw new Error('gitUrls must be more than two parameters');
+  }
 
-  const json = root.toJSON({ keepComments: true });
+  const firstUrl = gitUrls.splice(0, 1)
+  let allResult: Array<{ result: any, root: any, [propname: string]: any }> = []
+
+  const json: any = await Promise.all(gitUrls.map(async (url) => {
+    const newUrl: any = url
+    const root = await loadProto({
+      gitUrls: [...firstUrl, url],
+      branch,
+      accessToken,
+      resolvePath,
+    });
+    root.resolveAll();
+    const json: any = root.toJSON({ keepComments: true });
+    delete json.nested.google
+    delete json.nested.common
+
+    const [space, service]: any[] = newUrl.match(/:.+-proto/)[0].replace(/:|-proto/g, '').split('/')
+
+    allResult.push({
+      result: inspectNamespace(root),
+      root,
+      space,
+      service
+    })
+
+    return { space, service, json }
+  }))
+
 
   fs.mkdirpSync(path.join(process.cwd(), '.grpc-code-gen'));
 
   const jsonPath = path.join(process.cwd(), '.grpc-code-gen', 'root.json');
   await fs.writeJSON(jsonPath, json);
 
-  const result = inspectNamespace(root);
-
-  if (!result) {
+  if (!allResult.length) {
     throw new Error('None code gen');
   }
 
-  const { services, methods, messages, enums } = result;
-
-  const namespace: TNamespace = {};
-  messages.forEach((message) => {
-    const packageName = getPackageName(message.fullName);
-    const nameSpacePath = 'nested.' + packageName.replace(/\./g, '.nested.');
-    const latest = get(namespace, nameSpacePath, { messages: {} });
-    latest.messages[message.name] = message;
-    set(namespace, nameSpacePath, latest);
-  });
-  enums.forEach((enumT) => {
-    const packageName = getPackageName(enumT.fullName);
-    const nameSpacePath = 'nested.' + packageName.replace(/\./g, '.nested.');
-    const latest = get(namespace, nameSpacePath, { enums: {} });
-    latest.enums[enumT.name] = enumT;
-    set(namespace, nameSpacePath, latest);
-  });
-
+  
   const grpcObjPath = getAbsPath(`grpcObj.ts`, baseDir);
   await fs.writeFile(
     grpcObjPath,
@@ -96,11 +100,6 @@ export async function gen(opt: Options): Promise<string> {
     genGetGrpcClient(grpcNpmName, grpcClientPath),
   );
 
-  const typesPath = getAbsPath('types.ts', baseDir);
-  await fs.writeFile(
-    typesPath,
-    genTsType({ namespace, root, messages, enums, loaderOptions }),
-  );
 
   const serviceWrapperPath = getAbsPath(`serviceWrapper.ts`, baseDir);
   await fs.writeFile(
@@ -112,21 +111,59 @@ export async function gen(opt: Options): Promise<string> {
     }),
   );
 
-  await genServices({
-    grpcClientPath,
-    serviceWrapperPath,
-    messages,
-    methods,
-    grpcNpmName,
-    configFilePath: configFilePath as string,
-    grpcObjPath,
-    baseDir,
-    enums,
-    root,
-    services,
-    typesPath,
-    loaderOptions,
-  });
+
+  // 先清空一次
+  await fs.writeFile(getAbsPath('types.ts', baseDir), '');
+
+  allResult.map((item: { result: any, root: any, [propname: string]: any }, index: number) => {
+    
+    const { result, root, space, service } = item
+    const { services, methods, messages, enums } = result;
+
+    const namespace: TNamespace = {};
+    messages.forEach((message: any) => {
+      const packageName = getPackageName(message.fullName);
+      const nameSpacePath = 'nested.' + packageName.replace(/\./g, '.nested.');
+      const latest = get(namespace, nameSpacePath, { messages: {} });
+      latest.messages[message.name] = message;
+      set(namespace, nameSpacePath, latest);
+    });
+    enums.forEach((enumT: any) => {
+      const packageName = getPackageName(enumT.fullName);
+      const nameSpacePath = 'nested.' + packageName.replace(/\./g, '.nested.');
+      const latest = get(namespace, nameSpacePath, { enums: {} });
+      latest.enums[enumT.name] = enumT;
+      set(namespace, nameSpacePath, latest);
+    });
+
+    const typesPath = getAbsPath('types.ts', baseDir);
+    fs.appendFile(
+      typesPath,
+      genTsType({ namespace, root, messages, enums, loaderOptions, space, service, index }),
+    );
+
+    genServices({
+      grpcClientPath,
+      serviceWrapperPath,
+      messages,
+      methods,
+      grpcNpmName,
+      configFilePath: configFilePath as string,
+      grpcObjPath,
+      baseDir,
+      enums,
+      root,
+      services,
+      typesPath,
+      loaderOptions,
+      space,
+      service
+    });
+
+  })
+
+
+
 
   console.info(`Generate success in ${baseDir}`);
 

--- a/src/genGrpcObj.ts
+++ b/src/genGrpcObj.ts
@@ -17,14 +17,17 @@ export default function genGrpcObj(opt: {
     `import { loadFromJson } from 'load-proto';\n`,
     isNative ? `import { EventEmitter } from "events";` : `import { Status } from '${grpcNpmName}/build/src/constants';`,
     `const root = require('${getImportPath(grpcObjPath, jsonPath)}');\n`,
-    `let config;`,
+    `let config: any;`,
     `if (fs.existsSync(require.resolve('${getImportPath(grpcObjPath, configFilePath as string)}'))) {
   config = require('${getImportPath(grpcObjPath, configFilePath as string)}');
 }`,
-    `const grpcObject = grpc.loadPackageDefinition(loadFromJson(`,
-    `  root,`,
-    `  (config && config.loaderOptions) || { defaults: true },`,
-    `));\n`,
+    `const grpcObjectGroup: any = {}`,
+    `Object.keys(root).forEach((key: string) => {`,
+    ` grpcObjectGroup[key] = grpc.loadPackageDefinition(loadFromJson(`,
+    `   root[key],`,
+    `   (config && config.loaderOptions) || { defaults: true },`,
+    ` ));`,
+    `});\n`,
     `// fix: grpc-message header split by comma
 grpc.Metadata.prototype.getMap = function() {
   const result: any = {};
@@ -127,6 +130,6 @@ clientInterceptors.getLastListener = function (method_definition: any, emitter: 
     }
   });
 };`,
-    `export default grpcObject;`,
+    `export default grpcObjectGroup;`,
   ].join('\n')
 }

--- a/src/genServices.ts
+++ b/src/genServices.ts
@@ -67,7 +67,7 @@ export default async function genServices(opt: {
     space,
     service: service_
   } = opt;
-  
+
   // 新增团队级的文件夹
   baseDir = space ? `${baseDir}/${space}/${service_}` : baseDir
   service_ = service_.replace(/-/g, '_')
@@ -133,8 +133,8 @@ export default async function genServices(opt: {
         return 0;
       })
       .map((method) => {
-        const requestType = 'types.' + getTsType(method.requestType, packageName, config, false, space, service_).tsType;
-        const responseType = `types.${getTsType(method.responseType, packageName, config, false, space, service_).tsType}`;
+        const requestType = 'types.' + getTsType(method.requestType, packageName, config).tsType;
+        const responseType = `types.${getTsType(method.responseType, packageName, config).tsType}`;
         return `  /** @deprecated 请使用: ${method.name}V2 */
   ${method.name}(
     request: ${requestType},
@@ -172,7 +172,7 @@ export default async function genServices(opt: {
       `  restartServer?: Function;`,
       `  closeServer?: Function;`,
       `}`,
-      `const Service: ${typeName} = get<any, string>(grpcObject, '${service.fullName}');`,
+      `const Service: ${typeName} = get<any, string>(grpcObject, '${space}_${service_}.${service.fullName}');`,
       `Service.$FILE_NAME = '${service.filename && service.filename.replace(/\\/g, '/')}';`,
       `export const ${service.name}: ${typeName} = serviceWrapper<${typeName}>(Service);`,
       `export default ${service.name};`,

--- a/src/genServices.ts
+++ b/src/genServices.ts
@@ -48,8 +48,10 @@ export default async function genServices(opt: {
   root: Root;
   grpcObjPath: string;
   loaderOptions?: LoaderOptions;
+  space: string;
+  service: string;
 }): Promise<void> {
-  const {
+  let {
     grpcNpmName,
     grpcObjPath,
     typesPath,
@@ -62,7 +64,13 @@ export default async function genServices(opt: {
     messages,
     root,
     loaderOptions,
+    space,
+    service: service_
   } = opt;
+  
+  // 新增团队级的文件夹
+  baseDir = space ? `${baseDir}/${space}/${service_}` : baseDir
+  service_ = service_.replace(/-/g, '_')
 
   const getTsType = getTsTypeFactory(walkPackagePath, loaderOptions);
 
@@ -125,8 +133,8 @@ export default async function genServices(opt: {
         return 0;
       })
       .map((method) => {
-        const requestType = 'types.' + getTsType(method.requestType, packageName, config).tsType;
-        const responseType = `types.${getTsType(method.responseType, packageName, config).tsType}`;
+        const requestType = 'types.' + getTsType(method.requestType, packageName, config, false, space, service_).tsType;
+        const responseType = `types.${getTsType(method.responseType, packageName, config, false, space, service_).tsType}`;
         return `  /** @deprecated 请使用: ${method.name}V2 */
   ${method.name}(
     request: ${requestType},

--- a/src/genTsType.ts
+++ b/src/genTsType.ts
@@ -36,12 +36,17 @@ function doGenTsType(
     loaderOptions?: LoaderOptions,
   },
   deep: number = 0,
+  space_: string,
+  service: string,
+  index: number = 0,
 ): string {
   const getTsType = getTsTypeFactory(walkPackagePath, config.loaderOptions);
 
   let str = '';
   const { messages, enums, nested } = namespace;
   const space = genSpace(deep * 2);
+  service = service.replace(/-/g, '_')
+
   if (messages) {
     str += Object
       .keys(messages)
@@ -59,7 +64,7 @@ function doGenTsType(
         const fieldDefine = message.fields
           .map((field) => {
             const isArr = field.repeated;
-            const { tsType, semanticType } = getTsType(field.type, message.fullName, config, isArr);
+            const { tsType, semanticType } = getTsType(field.type, message.fullName, config, isArr, space_, service);
 
             let res = `${space}  '${field.name}'${field.required ? '' : '?'}: `;
 
@@ -125,8 +130,16 @@ function doGenTsType(
         return 0;
       })
       .map((name) => {
-        str += `${space}export namespace ${name} {\n`;
-        str += doGenTsType(nested[name], config, nextDeep);
+        if ((name === 'common' || name === 'google') && index > 0) {
+          return
+        }
+        // common 和 google不需要加前缀，第二层即以上命名空间不需要加前缀
+        const namespace =
+          name !== 'common' && name !== 'google' && space_ && service && nextDeep <= 1
+            ? `n_${space_}_${service}_${name}` : name
+
+        str += `${space}export namespace ${namespace} {\n`;
+        str += doGenTsType(nested[name], config, nextDeep, space_, service, index);
         str += `${space}}\n`;
       });
   }
@@ -138,7 +151,10 @@ export default function genTsType(opt: {
   root: Root;
   messages: TMessage[];
   enums: TEnum[];
+  space: string;
+  service: string;
   loaderOptions?: LoaderOptions,
+  index?: number;
 }): string {
   const {
     namespace,
@@ -146,6 +162,9 @@ export default function genTsType(opt: {
     messages,
     enums,
     loaderOptions,
+    space,
+    service,
+    index
   } = opt;
 
   const messageMap: { [key: string]: TMessage } = {};
@@ -161,6 +180,6 @@ export default function genTsType(opt: {
   return [
     fileTip,
     tslintDisable,
-    doGenTsType(namespace, { root, messageMap, enumMap, loaderOptions, }),
+    doGenTsType(namespace, { root, messageMap, enumMap, loaderOptions }, 0, space, service, index),
   ].join('\n');
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,6 +79,8 @@ export function getTsTypeFactory(
       enumMap: { [key: string]: TEnum },
     },
     isArr?: boolean,
+    space?: string,
+    service?: string,
   ): { tsType: string, semanticType?: string, basic: boolean } {
     let basic = PROTO_TYPE_2_TS_TYPE_MAP[protoType];
     if (basic) {
@@ -115,6 +117,8 @@ export function getTsTypeFactory(
     }
 
     if (tsType) {
+      // 排除 google 类
+      tsType = /^google/.test(tsType) ? tsType : `n_${space}_${service}_${tsType}`
       return {
         tsType: tsType,
         semanticType: isArr ? `ArraySchemaWithGenerics<${tsType}>` : undefined,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,8 +79,6 @@ export function getTsTypeFactory(
       enumMap: { [key: string]: TEnum },
     },
     isArr?: boolean,
-    space?: string,
-    service?: string,
   ): { tsType: string, semanticType?: string, basic: boolean } {
     let basic = PROTO_TYPE_2_TS_TYPE_MAP[protoType];
     if (basic) {
@@ -117,8 +115,6 @@ export function getTsTypeFactory(
     }
 
     if (tsType) {
-      // 排除 google 类
-      tsType = /^google/.test(tsType) ? tsType : `n_${space}_${service}_${tsType}`
       return {
         tsType: tsType,
         semanticType: isArr ? `ArraySchemaWithGenerics<${tsType}>` : undefined,


### PR DESCRIPTION
1、更新types生成规则，所有生成的types 命名空间之前新增 n_${空间名}_${服务名}