### PR TITLE
适配stream

### DIFF
--- a/src/genServiceWrapper.ts
+++ b/src/genServiceWrapper.ts
@@ -147,7 +147,17 @@ export default function serviceWrapper<Type>(Service: Type): Type {
 
         doCall(this);
       };
+
+      const wrapper2 = function(this: any, request: any) {
+        function doCall(self: any) {
+          let res = (origin as any).apply(self, [request]);
+          return res
+        }
+        return doCall(this);
+      };
+
       (Service as any).prototype[key] = promisify(wrapper);
+      (Service as any).prototype[\`\$\{key\}V3\`] = wrapper2;
       (Service as any).prototype[\`\$\{key\}V2\`] = function(option: ReqOptions) {
         const { request, metadata = {}, options } = option;
         return new Promise((resolve, reject) => {

--- a/src/genServices.ts
+++ b/src/genServices.ts
@@ -155,6 +155,12 @@ export default async function genServices(opt: {
     request: ${requestType};
     metadata?: MetadataMap;
     options?: { timeout?: number; flags?: number; host?: string; };
+  }): Promise<{ response:${responseType}, metadata: Metadata }>;
+  ${method.comment ? `/** ${method.comment} */` : ''}
+  ${method.name}V3(option: {
+    request: ${requestType};
+    metadata?: MetadataMap;
+    options?: { timeout?: number; flags?: number; host?: string; };
   }): Promise<{ response:${responseType}, metadata: Metadata }>;`
       });
 


### PR DESCRIPTION
在src/genServices.ts 文件中，新增 `${method.name}V3` 方法。
在src/genServiceWrapper.ts 文件中，新增一个wrapper2 ，将后缀为V3的方法使用 wrapper2进行处理，进行返回gRPC请求的结果。如有错误，烦请指正。
